### PR TITLE
Stop mailing list form overlapping page width

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,7 @@
                   <form class="form" action="https://tinyletter.com/nhshackday" method="post" target="popupwindow" onsubmit="window.open('https://tinyletter.com/nhshackday', 'popupwindow', 'scrollbars=yes,width=800,height=600');return true">
                     <label for="tlemail">Sign up to our mailing list for news and announcements: </label>
                     <div class="form-group row">
-                      <div class="col-md-10">
+                      <div class="col-md-8">
                         <div class="input-group">
                           <span class="input-group-addon">
                             <span class="glyphicon glyphicon-envelope"></span>
@@ -27,7 +27,7 @@
                           <input type="email" class="form-control" name="email" id="tlemail" /><input type="hidden" value="1" name="embed"/>
                         </div>
                       </div>
-                      <div class="col-md-2" align="right">
+                      <div class="col-md-4" align="right">
                         <input class="btn btn-info" type="submit" value="Subscribe" />
                       </div>
                     </div>


### PR DESCRIPTION
On chrome it currently looks like this:

![](http://cdn2.dropmark.com/9456/ea664c0b4a3ff705b1a790ec779caceec2501e7a/Screenshot%202016-05-16%2023.35.03.png)