### PR TITLE
Remove Gloucester from front page.....

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,25 +30,8 @@ layout: default
     <div class="container">
       <div class="row">
         <h4>Upcoming NHS Hack Day events:</h4>
-        <a href="https://ti.to/nhshackday/nhshd-gloucester" target="_blank">
-          <div class="col-md-4 col-md-offset-1">
-            <h2>Gloucester</h2>
-            <h5>
-              <i class="fa fa-calendar"></i>
-              October 14-15 2017
-            </h5>
-            <center>
-                <p>
-                  <a class="btn btn-default btn-lg" target="_blank" href="https://ti.to/nhshackday/nhshd-gloucester">
-                    Sign up now
-                  </a>
-                </p>
-            </center>
-          </div>
-        </a>
 
-        <!-- <a target="_blank" href="https://ti.to/nhshackday/nhshd-16-manchester/"> -->
-          <div class="col-md-4 col-md-offset-2">
+          <div class="col-md-4 col-md-offset-4">
             <h2>Cardiff</h2>
             <h5>
               <i class="fa fa-calendar"></i>
@@ -62,7 +45,6 @@ layout: default
               </p>
             </center>
           </div>
-        <!-- </a> -->
 
       </div> <!-- row -->
     </div>   <!-- container -->


### PR DESCRIPTION
Remove Gloucester from front page, and ensure it is linked to in the Past Events page. Re-centred Cardiff 2018