### PR TITLE
Specify minimum Jekyll version required to build the site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
+gem 'jekyll', '>=3.2.0'
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-compress-images'


### PR DESCRIPTION
Disclaimer: I couldn't Ruby my way out of a paper bag, this could be utterly the wrong thing to do.

When running `bundle install; bundle exec jekyll serve` prior to this change to the Gemfile I get errors about the use of the `{% link` tag which was introduced in this version.