### PR TITLE
Add missing project from #01-london.

### DIFF
--- a/content/_projects/01-london/coincidence_gate.md
+++ b/content/_projects/01-london/coincidence_gate.md
@@ -1,0 +1,11 @@
+---
+hackday: 01-london
+summary: Develop an automated measure of conflicted-ness for particular drug/field. As it is difficult to see conflicts of interest by subject/researcher. 
+team:
+- Adrian Wilkins
+- Matt Cutting
+- Helga Perry
+- Chris Martin
+- Chris Dankwa
+title: CoIncidence Gate
+---


### PR DESCRIPTION
Add missing project from #01-london. Found in https://www.slideshare.net/ideogram/london-nhs-hack-day-presentation-may-2012